### PR TITLE
Refresh GPT Sherpa homepage with hero and card layout

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -16,7 +16,7 @@ project:
 
 website:
   title: "GPT Sherpa"
-  description: "Practical patterns for working with LLMs."
+  description: "Claude Code setup guides, CLAUDE.md templates, Quarto authoring patterns, and reusable LLM workflow skills for data scientists and engineers."
   site-url: "https://gptserpa.com"
   navbar:
     left:
@@ -82,6 +82,7 @@ website:
 format:
   html:
     theme: cosmo
+    css: styles.css
     toc: true
     toc-depth: 3
     toc-location: left

--- a/index.qmd
+++ b/index.qmd
@@ -1,61 +1,150 @@
 ---
 title: "GPT Sherpa"
-description: "Practical patterns for working with LLMs."
+description: "Claude Code setup guides, CLAUDE.md templates, Quarto authoring patterns, and reusable LLM workflow skills for data scientists and engineers."
 pagetitle: "GPT Sherpa"
 toc: false
 ---
 
-# Practical patterns for working with LLMs
+# Production-tested LLM workflow patterns
 
-A working data scientist's notebook of patterns that hold up in production:
-how to set up Claude Code, how to write CLAUDE.md control documents that
-make an LLM behave, how to author Quarto documents with LLM help, and a
-small library of templates you can copy.
+::: {.sherpa-hero}
 
-Not generic LLM hype, not vendor docs — patterns proven on real projects,
-generalized for anyone to reuse.
+GPT Sherpa is a field notebook for data scientists and software engineers
+using LLMs on real projects: Claude Code setup, `CLAUDE.md` control files,
+Quarto authoring workflows, and copyable skills that make AI-assisted work
+more reliable.
 
-## Three places to start
+Not prompt hacks. Not vendor docs. These are practical patterns that survived
+real work, then got cleaned up so you can reuse them.
 
-::: {.grid}
+::: {.sherpa-actions}
 
-::: {.g-col-12 .g-col-md-4}
-### New to Claude Code?
-
-The setup guide walks through installing the CLI, configuring permissions,
-and adding your first custom skill.
-
-[Claude Code setup →](guides/claude-code-setup.md)
+::: {.sherpa-action .sherpa-action-primary}
+[Start with Claude Code setup →](guides/claude-code-setup.md)
 :::
 
-::: {.g-col-12 .g-col-md-4}
-### Already running Claude Code?
-
-Make it work better. A `CLAUDE.md` control document is how you teach an
-LLM your project. Start from the template, refine as the project grows.
-
-[CLAUDE.md template →](templates/claude-md-project.md)
-:::
-
-::: {.g-col-12 .g-col-md-4}
-### Authoring with Quarto?
-
-A reference skill that captures Quarto execution control, journal
-formatting, cross-references, citations — and a one-page LLM cheatsheet.
-
-[Quarto authoring skill →](skills/quarto-skill.qmd)
+::: {.sherpa-action}
+[Copy a project CLAUDE.md →](templates/claude-md-project.md)
 :::
 
 :::
 
-## What's here
+:::
 
-- **Getting started** — what LLM-assisted work looks like; a quick GitHub Copilot primer.
-- **Claude Code** — setup and an opinionated architecture-review pattern for organizing projects with Claude.
-- **Quarto** — authoring skill, an LLM cheatsheet, and the ontology-website pattern.
-- **Skills & patterns** — drop-in skill files for AskSage multi-model review, data profiling, PHI scanning, knowledge vaults, txtarchive, Rhino + Shiny, and tidymodels.
-- **Templates** — project and global `CLAUDE.md` starters, a permissions `settings.local.json`, an ontology project scaffold, and a Quarto research-paper starter pack.
+## Choose your starting point
+
+::: {.grid .sherpa-card-grid}
+
+::: {.g-col-12 .g-col-md-4 .sherpa-card}
+### I am setting up Claude Code
+
+Install the CLI, configure permissions, and add your first custom skill without
+guessing which defaults matter.
+
+[Use the setup guide →](guides/claude-code-setup.md)
+:::
+
+::: {.g-col-12 .g-col-md-4 .sherpa-card}
+### I already use Claude Code
+
+Give the model durable project memory with a `CLAUDE.md` file. Start from a
+template, then refine the instructions as the project grows.
+
+[Copy the CLAUDE.md template →](templates/claude-md-project.md)
+:::
+
+::: {.g-col-12 .g-col-md-4 .sherpa-card}
+### I write with Quarto
+
+Use LLMs to author Quarto documents while keeping execution control,
+cross-references, citations, and reproducible outputs intact.
+
+[Open the Quarto authoring skill →](skills/quarto-skill.qmd)
+:::
+
+:::
+
+## What you can copy
+
+::: {.grid .sherpa-card-grid}
+
+::: {.g-col-12 .g-col-md-6 .sherpa-card}
+### Claude Code workflows
+
+- [Claude Code setup](guides/claude-code-setup.md) — install, configure, and
+  make the first skill useful.
+- [Architecture review pattern](guides/claude-code-architecture-review.md) —
+  organize a repo so Claude can reason about it without wandering.
+- [Project CLAUDE.md](templates/claude-md-project.md) — a starter control file
+  for project-specific behavior.
+- [Global CLAUDE.md](templates/claude-md-global.md) — reusable defaults for
+  your own working style.
+:::
+
+::: {.g-col-12 .g-col-md-6 .sherpa-card}
+### Quarto and publishing patterns
+
+- [Quarto authoring skill](skills/quarto-skill.qmd) — execution control,
+  journal formatting, citations, and cross-references.
+- [Quarto LLM cheatsheet](cheatsheets/quarto_llm_cheatsheet.qmd) — the compact
+  version when you need the rules close at hand.
+- [Ontology website pattern](guides/quarto-ontology-website.md) — a pattern for
+  turning structured domain knowledge into a navigable site.
+- [Research paper starter](templates/research-paper-starter-pack/README.md) —
+  a Quarto scaffold for paper-style writing.
+:::
+
+::: {.g-col-12 .g-col-md-6 .sherpa-card}
+### Data and review skills
+
+- [Data profiling](skills/data-profiling-skill.md) — inspect data before asking
+  an LLM to explain or model it.
+- [AskSage review](skills/asksage-review-skill.md) — package multi-model review
+  into a repeatable workflow.
+- [Tidymodels](skills/tidymodels-skill.md) — capture modeling conventions in a
+  reusable skill.
+- [Rhino + Shiny](skills/rhino-shiny-skill.md) — guide LLM-assisted work in a
+  structured Shiny application.
+:::
+
+::: {.g-col-12 .g-col-md-6 .sherpa-card}
+### Regulated and knowledge-work patterns
+
+- [PHI scanning](skills/phi-scanning-skill.md) — make sensitive-data review an
+  explicit step instead of an afterthought.
+- [Knowledge vault pattern](guides/knowledge-vault.md) — organize reusable
+  project context so models can retrieve the right background.
+- [Knowledge vault skill](skills/knowledge-vault-skill.md) — the drop-in skill
+  version of the pattern.
+- [txtarchive](skills/txtarchive-skill.md) — work with archived text in a way
+  that stays inspectable.
+:::
+
+:::
+
+## Why this exists
+
+LLM-assisted work breaks down when the model has no project context, no
+operating rules, and no way to tell exploratory notes from production
+constraints. GPT Sherpa treats those pieces as part of the workflow:
+write the control document, name the assumptions, keep reusable patterns close,
+and make the next run better than the last one.
+
+The result is not a magic prompt. It is a small operating system for using LLMs
+with code, data, and technical writing.
+
+## Useful first files
+
+- **For a new repo** — start with the
+  [Project CLAUDE.md template](templates/claude-md-project.md).
+- **For a personal default** — adapt the
+  [Global CLAUDE.md template](templates/claude-md-global.md).
+- **For Quarto writing** — keep the
+  [Quarto LLM cheatsheet](cheatsheets/quarto_llm_cheatsheet.qmd) open.
+- **For structured domain work** — copy the
+  [Ontology scaffold](templates/ontology-scaffold/README.md).
 
 ---
 
-*Source: [llmcheatsheets on GitHub](https://github.com/harlananelson/llmcheatsheets) (MIT licensed).*
+Source: [llmcheatsheets on GitHub](https://github.com/harlananelson/llmcheatsheets).
+Licensed for reuse under the repository terms.

--- a/styles.css
+++ b/styles.css
@@ -131,10 +131,11 @@ main.content code {
     background 160ms ease;
 }
 
-.sherpa-action-primary a {
+.sherpa-action.sherpa-action-primary a,
+.sherpa-action.sherpa-action-primary a:visited {
   border-color: var(--sherpa-accent);
   background: var(--sherpa-accent);
-  color: #ffffff;
+  color: #ffffff !important;
 }
 
 .sherpa-action a:hover {
@@ -144,9 +145,17 @@ main.content code {
   color: var(--sherpa-accent-dark);
 }
 
-.sherpa-action-primary a:hover {
+.sherpa-action.sherpa-action-primary a:hover,
+.sherpa-action.sherpa-action-primary a:focus,
+.sherpa-action.sherpa-action-primary a:focus-visible {
   background: var(--sherpa-accent-dark);
-  color: #ffffff;
+  border-color: var(--sherpa-accent-dark);
+  color: #ffffff !important;
+}
+
+.sherpa-action a:focus-visible {
+  outline: 3px solid var(--sherpa-accent);
+  outline-offset: 3px;
 }
 
 .sherpa-card-grid {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,215 @@
+/* GPT Sherpa custom layer
+   Drop this in as styles.css and reference it from _quarto.yml:
+
+   format:
+     html:
+       theme: cosmo
+       css: styles.css
+
+   This layer keeps Quarto's documentation affordances but gives the homepage
+   stronger hierarchy, warmer surfaces, and more intentional cards.
+*/
+
+:root {
+  --sherpa-bg: #f7f4ed;
+  --sherpa-surface: #fffdf8;
+  --sherpa-surface-alt: #f1ece1;
+  --sherpa-border: #ddd4c3;
+  --sherpa-text: #25221c;
+  --sherpa-muted: #6f675b;
+  --sherpa-accent: #0b6f76;
+  --sherpa-accent-dark: #084d55;
+  --sherpa-accent-soft: #dceff0;
+  --sherpa-code: #7c3f00;
+  --sherpa-radius: 18px;
+  --sherpa-shadow: 0 14px 38px rgba(55, 44, 28, 0.08);
+}
+
+body.quarto-light {
+  background:
+    radial-gradient(circle at top left, rgba(11, 111, 118, 0.08), transparent 28rem),
+    linear-gradient(180deg, var(--sherpa-bg) 0%, #fbfaf6 42%, #ffffff 100%);
+  color: var(--sherpa-text);
+}
+
+.navbar {
+  border-bottom: 1px solid rgba(221, 212, 195, 0.72);
+  box-shadow: none;
+}
+
+.navbar-title {
+  letter-spacing: -0.02em;
+  font-weight: 650;
+}
+
+.quarto-title-block .title,
+h1.title {
+  display: none;
+}
+
+main.content {
+  max-width: 980px;
+}
+
+main.content > h1:first-of-type {
+  margin-top: clamp(2rem, 7vw, 5rem);
+  max-width: 12ch;
+  color: var(--sherpa-text);
+  font-size: clamp(2.6rem, 8vw, 5.6rem);
+  line-height: 0.95;
+  letter-spacing: -0.065em;
+}
+
+main.content > h2 {
+  margin-top: clamp(3rem, 7vw, 5rem);
+  padding-top: 0.65rem;
+  border-top: 1px solid var(--sherpa-border);
+  color: var(--sherpa-text);
+  font-size: clamp(1.55rem, 3vw, 2.1rem);
+  letter-spacing: -0.035em;
+}
+
+main.content p {
+  color: var(--sherpa-muted);
+  font-size: 1.03rem;
+  line-height: 1.72;
+}
+
+main.content a {
+  color: var(--sherpa-accent);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.18em;
+}
+
+main.content a:hover {
+  color: var(--sherpa-accent-dark);
+}
+
+main.content code {
+  color: var(--sherpa-code);
+  background: rgba(124, 63, 0, 0.08);
+  border: 1px solid rgba(124, 63, 0, 0.1);
+  border-radius: 0.35rem;
+  padding: 0.08rem 0.28rem;
+}
+
+.sherpa-hero {
+  max-width: 760px;
+  margin-top: 1.15rem;
+  margin-bottom: clamp(2.5rem, 6vw, 4rem);
+}
+
+.sherpa-hero p:first-child {
+  color: var(--sherpa-text);
+  font-size: clamp(1.12rem, 2vw, 1.32rem);
+  line-height: 1.62;
+}
+
+.sherpa-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 1.65rem;
+}
+
+.sherpa-action a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.8rem;
+  padding: 0.78rem 1rem;
+  border: 1px solid var(--sherpa-border);
+  border-radius: 999px;
+  background: var(--sherpa-surface);
+  color: var(--sherpa-accent-dark);
+  font-weight: 650;
+  text-decoration: none;
+  box-shadow: 0 4px 14px rgba(55, 44, 28, 0.05);
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.sherpa-action-primary a {
+  border-color: var(--sherpa-accent);
+  background: var(--sherpa-accent);
+  color: #ffffff;
+}
+
+.sherpa-action a:hover {
+  transform: translateY(-1px);
+  border-color: var(--sherpa-accent);
+  background: var(--sherpa-accent-soft);
+  color: var(--sherpa-accent-dark);
+}
+
+.sherpa-action-primary a:hover {
+  background: var(--sherpa-accent-dark);
+  color: #ffffff;
+}
+
+.sherpa-card-grid {
+  row-gap: 1rem;
+}
+
+.sherpa-card {
+  min-height: 100%;
+  padding: clamp(1rem, 2.2vw, 1.35rem);
+  border: 1px solid var(--sherpa-border);
+  border-radius: var(--sherpa-radius);
+  background: rgba(255, 253, 248, 0.86);
+  box-shadow: var(--sherpa-shadow);
+}
+
+.sherpa-card h3 {
+  margin-top: 0;
+  color: var(--sherpa-text);
+  font-size: 1.18rem;
+  line-height: 1.25;
+  letter-spacing: -0.025em;
+}
+
+.sherpa-card p {
+  margin-bottom: 0.85rem;
+  font-size: 0.98rem;
+}
+
+.sherpa-card ul {
+  padding-left: 1.1rem;
+}
+
+.sherpa-card li {
+  margin-bottom: 0.58rem;
+  color: var(--sherpa-muted);
+  line-height: 1.55;
+}
+
+.sherpa-card li::marker {
+  color: var(--sherpa-accent);
+}
+
+hr {
+  margin-top: 3rem;
+  border-color: var(--sherpa-border);
+  opacity: 1;
+}
+
+@media (max-width: 767px) {
+  main.content {
+    padding-left: 1.05rem;
+    padding-right: 1.05rem;
+  }
+
+  main.content > h1:first-of-type {
+    max-width: 10ch;
+  }
+
+  .sherpa-actions {
+    display: grid;
+  }
+
+  .sherpa-action a {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary

- Replace `index.qmd` with a hero + action-button layout and a richer "what you can copy" card grid (`sherpa-hero`, `sherpa-actions`, `sherpa-card-grid`, `sherpa-card`).
- Add `styles.css` — a custom design layer that sits on top of the existing `cosmo` theme: warmer surfaces, stronger hierarchy, pill-style action buttons, intentional cards.
- Wire the new stylesheet in `_quarto.yml` via `format.html.css: styles.css` (theme and other format settings preserved).
- Update the site-level `description` in `_quarto.yml` to match the new homepage framing: "Claude Code setup guides, CLAUDE.md templates, Quarto authoring patterns, and reusable LLM workflow skills for data scientists and engineers."

## Files changed

- `index.qmd` (rewritten)
- `styles.css` (new)
- `_quarto.yml` (description + `css: styles.css`)

## Test plan

- [x] `./build.sh` runs end-to-end and emits `_site/index.html` (29/29 files rendered).
- [x] Rendered `_site/index.html` links `styles.css` and contains the `sherpa-hero` / `sherpa-card` classes.
- [x] Existing `cosmo` theme, navbar, TOC, and other `format.html` settings preserved in `_quarto.yml`.
- [ ] Visual QA in a browser (not done in this headless run — recommend a local preview before merge).

## Caveats

- The Quarto render emits two pre-existing warnings unrelated to this PR: an unresolved link to `skills/quarto-skill.md` and a fenced-div `:::` warning in `skills/quarto-skill.qmd`.
- No browser-based visual QA was performed in this environment; the layout was only verified via the rendered HTML markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)