### PR TITLE
Fix render workflow output path to match Quarto output-dir

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -16,10 +16,10 @@ jobs:
           set -euo pipefail
           quarto --version
           quarto render "cheatsheets/quarto_llm_cheatsheet.qmd" --to html --no-execute
-          test -f "cheatsheets/quarto_llm_cheatsheet.html"
+          test -f "_site/cheatsheets/quarto_llm_cheatsheet.html"
       - name: Upload HTML artifact
         uses: actions/upload-artifact@v4
         with:
           name: html
           if-no-files-found: error
-          path: cheatsheets/quarto_llm_cheatsheet.html
+          path: _site/cheatsheets/quarto_llm_cheatsheet.html


### PR DESCRIPTION
## Summary
- Workflow run [26407609739](https://github.com/harlananelson/llmcheatsheets/actions/runs/26407609739) failed because `test -f cheatsheets/quarto_llm_cheatsheet.html` always fails: `_quarto.yml` declares `project.type: website` with `output-dir: _site`, so `quarto render` writes to `_site/cheatsheets/quarto_llm_cheatsheet.html` (Quarto's own log confirms `Output created: ../_site/cheatsheets/quarto_llm_cheatsheet.html`).
- Update the existence check and the `upload-artifact` `path` in `.github/workflows/render.yml` to point at the real output location under `_site/`.

## Testing
- [ ] CI on this branch runs the render workflow successfully (verified via the `workflow_dispatch` trigger or by merging).
- Local Quarto rendering not run here — `quarto` is not installed in this environment. `local_quarto_check.sh` has the same pre-existing assumption about the output path but is out of scope for this minimal fix; it will need a follow-up if used as a pre-push gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)