### PR TITLE
Fix local_quarto_check.sh output path to match _site output-dir

### DIFF
--- a/local_quarto_check.sh
+++ b/local_quarto_check.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 QMD="${QMD:-cheatsheets/quarto_llm_cheatsheet.qmd}"   # override with: QMD=foo.qmd ./local_quarto_check.sh
+OUTPUT_DIR="${OUTPUT_DIR:-_site}"                     # matches output-dir in _quarto.yml
 
 echo "=== STATE CHECK ==="
 command -v quarto >/dev/null || { echo "Quarto CLI not found. On macOS: brew install --cask quarto"; exit 1; }
@@ -12,13 +13,13 @@ test -f "$QMD" || { echo "Missing $QMD in repo root."; exit 1; }
 echo
 echo "=== Render HTML (no code execution) ==="
 quarto render "$QMD" --to html --no-execute
-HTML_OUT="${QMD%.qmd}.html"
+HTML_OUT="${OUTPUT_DIR}/${QMD%.qmd}.html"
 test -f "$HTML_OUT" && echo "OK: $HTML_OUT created" || { echo "FAIL: $HTML_OUT not found"; exit 1; }
 
 echo
 echo "=== Render PDF (optional) ==="
+PDF_OUT="${OUTPUT_DIR}/${QMD%.qmd}.pdf"
 if quarto render "$QMD" --to pdf --no-execute; then
-  PDF_OUT="${QMD%.qmd}.pdf"
   test -f "$PDF_OUT" && echo "OK: $PDF_OUT created" || echo "PDF render ran but file missing"
 else
   echo "PDF render failed (likely missing LaTeX). To install TinyTeX locally:"
@@ -28,4 +29,4 @@ fi
 echo
 echo "=== DONE ==="
 ls -lh "$HTML_OUT" 2>/dev/null || true
-ls -lh "${QMD%.qmd}.pdf" 2>/dev/null || true
+ls -lh "$PDF_OUT" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- `local_quarto_check.sh` was validating rendered files next to the source (`cheatsheets/quarto_llm_cheatsheet.html`), but `_quarto.yml` sets `output-dir: _site`, so renders actually land at `_site/cheatsheets/quarto_llm_cheatsheet.html`.
- This mirrors the workflow fix from PR #5 (`.github/workflows/render.yml`), giving the local check the same path assumption as CI.
- Introduces an `OUTPUT_DIR` variable (default `_site`, overridable via env) and updates the HTML/PDF existence checks and final `ls` to use it.

## Testing

- [x] `bash -n local_quarto_check.sh` — passes
- [ ] Full `./local_quarto_check.sh` run — not executed; `quarto` is not available in this environment
- [x] Manual diff review against `.github/workflows/render.yml` (matches CI's `_site/cheatsheets/quarto_llm_cheatsheet.html` assertion)

## Caveats

- End-to-end render not exercised locally (no Quarto CLI available here). Path logic was verified against `_quarto.yml` (`output-dir: _site`) and the CI workflow updated in PR #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)