### PR TITLE
Opt JS actions into Node.js 24 to silence deprecation warning

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   render:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to `.github/workflows/render.yml` so the bundled JavaScript actions (`actions/checkout@v4`, `actions/upload-artifact@v4`) run on Node.js 24 instead of the deprecated Node.js 20 runtime.
- Resolves the non-blocking GitHub Actions annotation: *"Node.js 20 actions are deprecated… Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026."*
- Minimal change — no action version bumps, no behavioral change to the render step.

## Why this approach

`actions/checkout@v4` and `actions/upload-artifact@v4` are still the current major versions; the deprecation is about the Node runtime they ship against, not the action API. Setting the opt-in env var is the GitHub-recommended way to switch runtimes early without re-pinning action versions.

## Testing

- [x] Local YAML syntax validation: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/render.yml'))"` → valid
- [ ] CI: render workflow runs on this branch and the deprecation annotation no longer appears
- [ ] HTML artifact is still produced at `_site/cheatsheets/quarto_llm_cheatsheet.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)