### PR TITLE
Upgrade workflow actions to Node 24-native versions

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -5,14 +5,11 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   render:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: quarto-dev/quarto-actions/setup@v2
       - name: Render HTML (no code execution)
         run: |
@@ -21,7 +18,7 @@ jobs:
           quarto render "cheatsheets/quarto_llm_cheatsheet.qmd" --to html --no-execute
           test -f "_site/cheatsheets/quarto_llm_cheatsheet.html"
       - name: Upload HTML artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: html
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 -> v5 (Node 24-native since v5.0.0).
- Bump `actions/upload-artifact` v4 -> v6 (Node 24-native by default since v6.0.0; v5 advertised Node 24 but still defaulted to Node 20).
- Remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var added in #7 — no longer needed once the actions natively run on Node 24.

## Why
PR #7 silenced the runtime via the env var, but GitHub still emitted the annotation:
> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/upload-artifact@v4.

Upgrading the action versions removes the underlying cause rather than just overriding the runtime, so the annotation should go away.

## Version selection
- `actions/checkout@v5` (latest stable: v6.0.2). v5 was the Node 24 cutover; v6 is also Node 24 with credential-persistence changes. Chose v5 for a minimal diff — can bump to v6 later if desired.
- `actions/upload-artifact@v6` (latest stable: v7.0.1). v6 release notes explicitly state v5 had only "preliminary" Node 24 support and still defaulted to Node 20; v6 is the first version that defaults to Node 24. v7 adds optional direct-upload features unrelated to this workflow.

## Testing
- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/render.yml'))"`).
- [ ] CI run on this PR completes successfully and the Node 20 deprecation annotation no longer appears.

## Caveats
- Both upgrades require GitHub Actions runner >= v2.327.1. `ubuntu-latest`-hosted runners satisfy this; self-hosted runners (none in use here) would need updating.
- No API changes are used from either action in this workflow, so no input/output adjustments were necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)